### PR TITLE
Rename Neon2 to Neon

### DIFF
--- a/_software/neon.md
+++ b/_software/neon.md
@@ -1,46 +1,46 @@
 ---
 layout: page
-title: Neon2
+title: Neon
 tab: Software
 permalink: /software/neon/
 ---
 
-Neon2 is a browser-based music notation editor written in JavaScript, designed for working with square notation. It uses [Verovio](http://www.verovio.org/index.xhtml) to dynamically render the symbolic music files in MEI format, updating the file in real time through a graphical interface. Neon2 can be used for creating new musical scores, making ground-truth data for machine learning, or for correcting errors from automated transcriptions in an OMR workflow. Neon2 is designed as part of an optical music recognition workflow, allowing for quick and easy correction of pitch and position errors created in the OMR process. Every component of our OMR process is designed as an accessible online application, to allow correction tasks to be crowdsourced from our partner organizations and community members.  
+Neon is a browser-based music notation editor written in JavaScript, designed for working with square notation. It uses [Verovio](http://www.verovio.org/index.xhtml) to dynamically render the symbolic music files in MEI format, updating the file in real time through a graphical interface. Neon can be used for creating new musical scores, making ground-truth data for machine learning, or for correcting errors from automated transcriptions in an OMR workflow. Neon is designed as part of an optical music recognition workflow, allowing for quick and easy correction of pitch and position errors created in the OMR process. Every component of our OMR process is designed as an accessible online application, to allow correction tasks to be crowdsourced from our partner organizations and community members.  
 <br>
 
 ## Demo
 
-You can try out Neon2 on our [demo page](https://ddmal.github.io/Neon2/). You can begin by selecting a link to a musical document that has undergone OMR, and then continue to insert, delete, or pitch shift notes on the page.  
+You can try out Neon on our [demo page](https://ddmal.github.io/Neon/). You can begin by selecting a link to a musical document that has undergone OMR, and then continue to insert, delete, or pitch shift notes on the page.  
 <br>
 
 ## Source Code
 
-Source code is available on the [Neon2 Github](https://github.com/DDMAL/Neon2).  
+Source code is available on the [Neon Github](https://github.com/DDMAL/Neon).  
 <br>
 
 ## Documentation
 
-Installation and instructions are available on the [Neon2 Wiki page](https://github.com/DDMAL/Neon2/wiki).  
+Installation and instructions are available on the [Neon Wiki page](https://github.com/DDMAL/Neon/wiki).  
 <br>
 
 ## Contributing Code
 
 Any contributions are welcome! The easiest way to submit code is:
 
-1. Create a fork of the [Neon2 Github repository](https://github.com/DDMAL/Neon2)
-2. Read through the documentation and familiarize yourself with the code. Look at same of the outstanding [issues and feature requests](https://github.com/DDMAL/Neon2/issues) if you need some inspiration.
+1. Create a fork of the [Neon Github repository](https://github.com/DDMAL/Neon)
+2. Read through the documentation and familiarize yourself with the code. Look at same of the outstanding [issues and feature requests](https://github.com/DDMAL/Neon/issues) if you need some inspiration.
 3. Change code as you please in your local repository.
 4. When you're ready, send us a pull request. We'll look through your code, and then merge it in.  
 <br>
 
 ## Feedback
 
-If you have any comments please [let us know](emily.hopkins@mcgill.ca). If you would like to see a particular feature implemented, post a new [issue](https://github.com/DDMAL/Neon2/issues) on the Neon2 Github.  
+If you have any comments please [let us know](emily.hopkins@mcgill.ca). If you would like to see a particular feature implemented, post a new [issue](https://github.com/DDMAL/Neon/issues) on the Neon Github.  
 <br>
 
 ## Developers    
 
-Neon2 is developed by:
+Neon is developed by:
 
 {% assign people = site.people | sort: 'last_name' %}
 
@@ -78,4 +78,4 @@ Project managers:
 
 ## Sponsors
 
-Neon2 is an ongoing project at the [Distributed Digital Music Archives and Libraries Lab (DDMAL)]({{ site.url }}/), at the [Schulich School of Music](http://www.mcgill.ca/music) of [McGill University](http://www.mcgill.ca/). Neon2 is part of the larger [Single Interface for Music Score Searching and Analysis (SIMSSA)](http://simssa.ca/) project that is generously funded by the [Social Sciences and Humanities Research Council of Canada](http://www.sshrc-crsh.gc.ca/). We're also grateful for the support provided by the [Centre for Interdisciplinary Research in Music Media and Technology (CIRMMT)](http://www.cirmmt.mcgill.ca/).
+Neon is an ongoing project at the [Distributed Digital Music Archives and Libraries Lab (DDMAL)]({{ site.url }}/), at the [Schulich School of Music](http://www.mcgill.ca/music) of [McGill University](http://www.mcgill.ca/). Neon is part of the larger [Single Interface for Music Score Searching and Analysis (SIMSSA)](http://simssa.ca/) project that is generously funded by the [Social Sciences and Humanities Research Council of Canada](http://www.sshrc-crsh.gc.ca/). We're also grateful for the support provided by the [Centre for Interdisciplinary Research in Music Media and Technology (CIRMMT)](http://www.cirmmt.mcgill.ca/).


### PR DESCRIPTION
We're only calling it Neon from now on and the repo has been renamed Neon, meaning all links also need to be updated.