### PR TITLE
Remove Colon for filename for windows compatibility

### DIFF
--- a/_OMRbibliography/1972/Kassler_Optical_character_recognition_of_printed_music_A_review_of_two_dissertations_1972.md
+++ b/_OMRbibliography/1972/Kassler_Optical_character_recognition_of_printed_music_A_review_of_two_dissertations_1972.md
@@ -1,0 +1,6 @@
+---
+presentation_year: 1972
+year: 1972
+---
+
+Kassler, Michael. 1972. “Optical Character Recognition of Printed Music: A Review of Two Dissertations.” <i>Perspectives of New Music</i> 11:250–54.


### PR DESCRIPTION
This pesky file has ruined my day for too many years because it causes all `git clone`s on Windows to fail. Away with you.