### PR TITLE
Improve accessibility link to past group photos

### DIFF
--- a/lab_members.md
+++ b/lab_members.md
@@ -49,7 +49,8 @@ tab: Lab_Members
 {% endfor %}
 </ul>
 {% assign alumni = site.lab_members | where:"category","Alumni" %}
-<h3 class="people-title"> Alumni </h3> See past group photos <a href="https://ddmal.music.mcgill.ca/people/">here</a>
+<h3 class="people-title"> Alumni </h3>
+<a href="https://ddmal.music.mcgill.ca/people/">Past group photos</a>
 <ul class="member-list">
 {% for member in alumni %}
   <li><a href='{{ member.url }}'>{{ member.title }}</a><a href='{{ member.url }}'><img class="member_photo_list" src="{{ site.baseurl }}/assets/lab_members/thumbnail/{{ member.photo }}" /></a></li>


### PR DESCRIPTION
This PR updates the link to the images of past group photos.

Previously, the line of text read "See past group photos [here](https://ddmal.music.mcgill.ca/people/)". Now, it reads "[Past group photos](https://ddmal.music.mcgill.ca/people/)".

This is important for accessibility purposes - previously, if someone was using a screen-reader and was tabbing from link to link, they'd come across a link called 'here' and will have no idea what it does.