### PR TITLE
Improve accessibility of link to past group photos

### DIFF
--- a/lab_members/index.html
+++ b/lab_members/index.html
@@ -152,8 +152,7 @@
               href="../lab_members/undergraduate/zhanna_klimanova/"><img class="member_photo_list"
                 src="../assets/lab_members/thumbnail/placeholder.png" /></a></li>
         </ul>
-        <h3 class="people-title"> Alumni </h3>
-        See past group photos <a href="https://ddmal.music.mcgill.ca/people/">here</a>
+        <h3 class="people-title"> Alumni </h3><a href="https://ddmal.music.mcgill.ca/people/">Past group photos</a>
         <ul class="member-list">
           <li><a href="../lab_members/alumni/adam_tindale/">Adam Tindale</a><a
               href="../lab_members/alumni/adam_tindale/"><img class="member_photo_list"


### PR DESCRIPTION
Because PR #90 was not merged before the website was de-forested, the suggested changes were not applied. This PR replicates the requested changes on the new version of the website code. 