### PR TITLE
Fix typo on index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,7 +95,7 @@
           <li><a href="research/Automatic_Metadata_Extraction/">Workflow Management with Automatic Metadata Extraction</a></li>
           <li><a href="research/Automatic_Music_Classification/">Automatic Music Classification</a></li>
           <li> Centre de Recherche sur l'Interprétation au Clavecin (CRIC) </li>
-          <li><a href="https://dact-chant.ca">DACT (Digital Analysis of CHant Transmission)</a></li>
+          <li><a href="https://dact-chant.ca">DACT (Digital Analysis of Chant Transmission)</a></li>
           <li><a href="research/Interlibrary_Communication/">Interlibrary Communication</a></li>
           <li><a href="https://linkedmusic.ca/">LinkedMusic</a></li>
           <li><a href="research/The_McGill_Image-to-Audio_Conversion_Project_(MltAC)/">The McGill Image-to-Audio Conversion Project (MltAC)</a></li>


### PR DESCRIPTION
This PR fixes the uppercase "H" in "DIgital Analysis of CHant Transmission" on the homepage.