### PR TITLE
Remove the domain migration alert message

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,11 +68,6 @@
     <div class="wrap">
       <div class="container content">
         <div style="text-align:center">
-          <div id="moving-domain" class="alert alert-warning" role="alert">
-            <strong>NOTICE:</strong>
-            <code>ddmal.music.mcgill.ca </code> will soon be moved to <code>ddmal.ca</code> <br>
-            Please update your bookmarks!
-          </div>
           <h1 class="home-title">Welcome!</h1>
           <div style="padding-top: 15px;"></div>
           <h3 style="font-weight:300;" class="subtitle">


### PR DESCRIPTION
- Reverting #181 because the domain is now `ddmal.ca` throughout the lab.
- Ref: #177 